### PR TITLE
MissionGameplay::OnKeyPress() is no more completely overwritten

### DIFF
--- a/5_Mission/missiongameplay.c
+++ b/5_Mission/missiongameplay.c
@@ -11,7 +11,9 @@ modded class MissionGameplay {
 		GetRPCManager().AddRPC("ClassSelection", "SyncConfig", this, SingeplayerExecutionType.Client);
 	}
 	
-	override void OnKeyPress( int key ) { 
+	override void OnKeyPress( int key ) {
+		super.OnKeyPress(key);
+	
 		switch ( key ) {
 			case ClassSelectionUtils.StringToKeyCode(m_Config.keyToOpen):
 				if(!m_Config.showClassSelectOnRespawnOnly) GetClassMenu().Toggle();


### PR DESCRIPTION
This issue was affecting other mods where this method was used (e.g. ZomBerry with custom keybinding system)